### PR TITLE
bigscape: reuse existing Pfam database

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to see all available parameters. Flags you may find useful:
   `antismash_conda_env_name` and `antismash_command` parameters in the config file.
 * **BiG-SCAPE** is turned off by default. The first time a BiG-SCAPE job is 
   requested (`run_bigscape: True` in the config file) then multiSMASH will 
-  automatically install `bigscape=1.1.5` and download the latest Pfam database.
+  automatically install `bigscape=1.1.5` and reuse the Pfam database from antiSMASH.
   If you want to use your own [BiG-SCAPE conda installation](https://github.com/medema-group/BiG-SCAPE/wiki/installation), 
   point multiSMASH to the correct locations with the last three parameters
   of the config file.

--- a/example/config-example.yaml
+++ b/example/config-example.yaml
@@ -81,8 +81,8 @@ antismash_command: antismash       # Or maybe `python /path/to/run_antismash.py`
 #   If you already have a BiG-SCAPE environment that you want to use,
 #   put the environment name here.
 bigscape_conda_env_name:
-bigscape_command:                 # Maybe python /path/to/bigscape/bigscape.py
+bigscape_command:                 # Maybe "bigscape.py" for some versions
 # BiG-SCAPE also requires a hmmpress'd Pfam database (Pfam-A.hmm plus .h3* files).
-#     It will be downloaded automatically (in /path/to/multismash/pfam),
-#     or if they already exist, you can specify the parent directory here.
+#   By default, multiSMASH uses antiSMASH's Pfam directory. If antiSMASH isn't installed,
+#   or multiSMASH instructs you to do so, set this to the directory containing Pfam-A.hmm.
 pfam_dir:                         # Relative paths are relative to THIS file!

--- a/multismash/main.py
+++ b/multismash/main.py
@@ -39,9 +39,14 @@ def install_bigscape(configs):
         conda_dir.mkdir(exist_ok=True)
         tar = Path(str(bigscape_dir) + ".tar.gz")
         if not tar.exists():
-            input(f"BiG-SCAPE will be downloaded to {bigscape_dir}/. Press Enter to continue.")
+            input(f"BiG-SCAPE will be downloaded and installed to {bigscape_dir}/. Press Enter to continue.")
             url = "https://github.com/medema-group/BiG-SCAPE/archive/refs/tags/v1.1.5.tar.gz"
-            subprocess.run(["curl", url, "-L", "-o", tar], check=True)
+            try:
+                subprocess.run(["curl", url, "-L", "-o", tar], check=True)
+            except Exception as e:
+                print(f"\n\n{type(e).__name__} detected: removing partial file")
+                subprocess.run(["rm", "-f", tar])
+                raise e
         subprocess.run(["tar", "-xzf", tar, "-C", conda_dir], check=True)
         assert(bigscape_dir.exists())
         tar.unlink()    # Delete

--- a/multismash/main.py
+++ b/multismash/main.py
@@ -46,29 +46,6 @@ def install_bigscape(configs):
         assert(bigscape_dir.exists())
         tar.unlink()    # Delete
 
-    # check if the Pfam files exist, and if not, download them
-    pfam_dir = configs["pfam_dir"]
-    if pfam_dir:
-        pfam = Path(args.configfile).parents[0] / Path(pfam_dir)
-        pfam = pfam.expanduser().resolve()
-    else:
-        pfam = Path(__file__).parents[1] / "pfam"
-    files = [pfam / ("Pfam-A.hmm" + ext) for ext in ["", ".gz", ".h3f", ".h3i", ".h3m", ".h3p"]]
-
-    # Only download if needed and after prompt
-    if not files[0].exists():  # Pfam-A.hmm
-        if not files[1].exists():  # Pfam-A.hmm.gz
-            Path.mkdir(pfam, exist_ok=True)
-            print("Downloading the Pfam database from EBI...")
-            url = "https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz"
-            subprocess.run(["curl", "-o", files[1], url], check=True)
-        subprocess.run(["gunzip", files[1]], check=True)
-
-    if not all((file.exists() for file in files[2:])):
-        print("Pressing the Pfam database...")
-        subprocess.run(["hmmpress", files[0]], check=True)
-        print("Done")
-
 
 def main():
     args, snakemake_args = parse_args()

--- a/multismash/main.py
+++ b/multismash/main.py
@@ -43,7 +43,7 @@ def install_bigscape(configs):
             url = "https://github.com/medema-group/BiG-SCAPE/archive/refs/tags/v1.1.5.tar.gz"
             try:
                 subprocess.run(["curl", url, "-L", "-o", tar], check=True)
-            except Exception as e:
+            except (KeyboardInterrupt, Exception) as e:
                 print(f"\n\n{type(e).__name__} detected: removing partial file")
                 subprocess.run(["rm", "-f", tar])
                 raise e

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -5,8 +5,6 @@ include: "rules/common.smk"
 paths = build_paths()
 GENOMES = get_samples(paths)
 
-BIG_ENV, BIG_COMMAND = get_bigscape_env()
-
 # Copy the config file into the log directory
 paths["LOG_DIR"].mkdir(parents=True)
 shutil.copy(workflow.configfiles[0], paths["LOG_DIR"] / "input_config.yaml")
@@ -76,20 +74,23 @@ rule count_regions:
 ## BiG-SCAPE rules
 
 if config["run_bigscape"]:
+    BIG_ENV, BIG_COMMAND, BIG_PFAM = get_bigscape_env()
+
     rule run_bigscape:
         input: expand(f"{paths['AS_DIR']}/{{genomes}}/{{genomes}}.gbk", genomes = GENOMES)
         params:
             asdir = paths['AS_DIR'],
             outdir = paths['BIG_DIR'],
-            pfam_dir = paths['PFAM_DIR'],
             bigscape_command = BIG_COMMAND,
-            bigscape_flags = config['bigscape_flags']
+            pfam_dir= BIG_PFAM,
+            bigscape_flags = config['bigscape_flags'],
+            cores = config['cores']
         output:
             directory(f"{paths['BIG_DIR']}"),
             f"{paths['BIG_DIR']}/index.html"
         conda: BIG_ENV
         shell: "{params.bigscape_command} -i {params.asdir} -o {params.outdir}"
-                " --pfam_dir {params.pfam_dir} {params.bigscape_flags}"
+                " -c {params.cores} --pfam_dir {params.pfam_dir} {params.bigscape_flags}"
 
     rule tar_bigscape:
         input: f"{paths['BIG_DIR']}/index.html"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -64,7 +64,26 @@ def get_bigscape_env():
     if not command:
         command = Path(workflow.basedir).parent / "conda" / "BiG-SCAPE-1.1.5" / "bigscape.py"
         command = f"python {command}"
-    return env, command
+
+    pfam = config["pfam_dir"]
+    # Use antismash functions to find and validate the Pfam directory
+    if not pfam:
+        exit_message = "Unable to locate Pfam-A.hmm. Please set the 'pfam_dir' " \
+                       "flag in the configuration file."
+        try:
+            from antismash.config import build_config
+            from antismash.common.pfamdb import get_latest_db_path, ensure_database_pressed
+        except ImportError:
+            raise SystemExit(exit_message)
+        try:
+            pfam = get_latest_db_path(build_config([]).database_dir)
+        except ValueError:
+            raise SystemExit(exit_message)
+        ensure_database_pressed(pfam)
+
+        pfam = pfam.replace("Pfam-A.hmm", "")   # We want the directory
+
+    return env, command, pfam
 
 
 def get_inputs_for_all(paths):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -79,7 +79,6 @@ def get_bigscape_env():
             pfam = get_latest_db_path(build_config([]).database_dir)
         except ValueError:
             raise SystemExit(exit_message)
-        ensure_database_pressed(pfam)
 
         pfam = pfam.replace("Pfam-A.hmm", "")   # We want the directory
 


### PR DESCRIPTION
If the user already has antiSMASH installed, they already have Pfam, so no need to download it in most cases.

-`get_bigscape_env` now locates the aS Pfam directory
-Removed the Pfam download section from `install_bigscape`

Also:

-Added `--cores` flag to run_bigscape command
-Updated readme and config comments to match